### PR TITLE
Ability to publish a database, switch to internal DB

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -26,7 +26,7 @@ jobs:
         pip install '.[test]'
     - name: Run tests
       run: |
-        pytest
+        python -m pytest
   deploy:
     runs-on: ubuntu-latest
     needs: [test]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,50 +12,41 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Configure pip caching
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: pip
+        cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install -e '.[test]'
+        pip install '.[test]'
     - name: Run tests
       run: |
         pytest
   deploy:
     runs-on: ubuntu-latest
     needs: [test]
+    environment: release
+    permissions:
+      id-token: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
-    - uses: actions/cache@v3
-      name: Configure pip caching
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-publish-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-publish-pip-
+        python-version: "3.12"
+        cache: pip
+        cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install setuptools wheel twine build
-    - name: Publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        pip install setuptools wheel build
+    - name: Build
       run: |
         python -m build
-        twine upload dist/*
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        datasette-version: ["<1.0", ">=1.0a13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -23,11 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install '.[test]'
-        pip install "datasette${{ matrix.datasette-version }}"
     - name: Run tests
       run: |
-        if [ -d tests/ ]; then
-          pytest
-        else
-          echo "No tests/ directory found, skipping"
-        fi
+        python -m pytest
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,24 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        datasette-version: ["<1.0", ">=1.0a13"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v3
-      name: Configure pip caching
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache: pip
+        cache-dependency-path: setup.py
     - name: Install dependencies
       run: |
-        pip install -e '.[test]'
+        pip install '.[test]'
+        pip install "datasette${{ matrix.datasette-version }}"
     - name: Run tests
       run: |
-        pytest
-
+        if [ -d tests/ ]; then
+          pytest
+        else
+          echo "No tests/ directory found, skipping"
+        fi

--- a/README.md
+++ b/README.md
@@ -20,10 +20,16 @@ This plugin can only be used with Datasette 1.0a+ and requires Datasette to be r
 ```bash
 datasette --internal internal.db data.db
 ```
+To grant `datasette-public` permission to the root user run the following:
+```bash
+datasette --internal internal.db data.db --root -s permissions.datasette-public.id root
+```
 
-A UI allows users with the `datasette-public` permission to toggle both tables and databases between public and private.
+New database and table action menu items allow users with the `datasette-public` permission to toggle both tables and databases between public and private.
 
-TODO: Make this true: Installing this plugin also causes `allow-sql` permission checks to fall back to checking if the user has access to the entire database. This is to avoid users with access to a single public table being able to access data from other tables using the `?_where=` query string parameter.
+For databases, users can also select if the ability to execute arbitrary SQL should be exposed to the public.
+
+If a table is public but the database is private, users will not we able to use the `?_where=` parameter on that table.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -10,47 +10,34 @@ Make specific Datasette tables visible to the public
 ## Installation
 
 Install this plugin in the same environment as Datasette.
-
-    datasette install datasette-public
-
+```bash
+datasette install datasette-public
+```
 ## Usage
 
-Any tables listed in the `_public_tables` table will be visible to the public, even if the rest of the Datasette instance does not allow anonymous access.
+This plugin can only be used with Datasette 1.0a+ and requires Datasette to be run with a persistent internal database:
 
-The root user (and any user with the new `public-tables` permission) will get a new option in the table action menu allowing them to toggle a table between public and private.
-
-Installing this plugin also causes `allow-sql` permission checks to fall back to checking if the user has access to the entire database. This is to avoid users with access to a single public table being able to access data from other tables using the `?_where=` query string parameter.
-
-## Configuration
-
-This plugin creates a new table in one of your databases called `_public_tables`.
-
-This table defaults to being created in the first database passed to Datasette.
-
-To create it in a different named database, use this plugin configuration:
-
-```json
-{
-  "plugins": {
-    "datasette-public": {
-      "database": "database_to_create_table_in"
-    }
-  }
-}
+```bash
+datasette --internal internal.db data.db
 ```
+
+A UI allows users with the `datasette-public` permission to toggle both tables and databases between public and private.
+
+TODO: Make this true: Installing this plugin also causes `allow-sql` permission checks to fall back to checking if the user has access to the entire database. This is to avoid users with access to a single public table being able to access data from other tables using the `?_where=` query string parameter.
 
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:
-
-    cd datasette-public
-    python3 -m venv venv
-    source venv/bin/activate
-
+```bash
+cd datasette-public
+python -m venv venv
+source venv/bin/activate
+```
 Now install the dependencies and test dependencies:
-
-    pip install -e '.[test]'
-
+```bash
+pip install -e '.[test]'
+```
 To run the tests:
-
-    pytest
+```bash
+pytest
+```

--- a/datasette_public/__init__.py
+++ b/datasette_public/__init__.py
@@ -47,9 +47,9 @@ def permission_allowed(datasette, action, actor, resource):
         if actor and actor.get("id") == "root" and action == "datasette-public":
             return True
         if action == "execute-sql" and not actor:
-            is_public, allow_sql = await database_privacy_settings(datasette, resource)
-            if not allow_sql:
-                return allow_sql
+            # We now have an opinion on execute-sql for anonymous users
+            _, allow_sql = await database_privacy_settings(datasette, resource)
+            return allow_sql
         if action not in ("view-table", "view-database"):
             return None
         if action == "view-table" and await table_is_public(

--- a/datasette_public/__init__.py
+++ b/datasette_public/__init__.py
@@ -126,7 +126,7 @@ def database_actions(datasette, actor, database):
                     "/-/public-database/{}".format(quote_plus(database))
                 ),
                 "label": "Make database {}".format(
-                    "private" if not is_public else "public"
+                    "private" if is_public else "public"
                 ),
                 "description": (
                     "Only allow logged-in users to view this database"

--- a/datasette_public/__init__.py
+++ b/datasette_public/__init__.py
@@ -48,17 +48,6 @@ def permission_allowed(datasette, action, actor, resource):
             return True
         if action == "execute-sql" and not actor:
             is_public, allow_sql = await database_privacy_settings(datasette, resource)
-            print(
-                "Check for actor",
-                actor,
-                "is_public",
-                "resource",
-                resource,
-                " - result: is_public",
-                is_public,
-                "allow_sql",
-                allow_sql,
-            )
             if not allow_sql:
                 return allow_sql
         if action not in ("view-table", "view-database"):

--- a/datasette_public/__init__.py
+++ b/datasette_public/__init__.py
@@ -1,18 +1,27 @@
 from datasette import hookimpl, Forbidden, Response, NotFound
 from urllib.parse import quote_plus, unquote_plus
+from typing import Optional, Tuple
 
-CREATE_TABLE_SQL = """
-create table _public_tables (table_name text primary key)
+CREATE_TABLES_SQL = """
+create table if not exists public_tables (
+    database_name text,
+    table_name text,
+    primary key (database_name, table_name)
+);
+create table if not exists public_databases (
+    database_name text primary key,
+    allow_sql integer default 0
+);
 """.strip()
 
 
 @hookimpl
 def startup(datasette):
     async def inner():
-        db = db_from_config(datasette)
-        assert db.is_mutable, "Database is immutable"
-        if "_public_tables" not in await db.table_names():
-            await db.execute_write(CREATE_TABLE_SQL)
+        db = datasette.get_internal_database()
+        if db.is_memory:
+            raise ValueError("datasette-public requires a persistent database")
+        await db.execute_write_script(CREATE_TABLES_SQL)
 
     return inner
 
@@ -21,66 +30,123 @@ def startup(datasette):
 def permission_allowed(datasette, action, actor, resource):
     async def inner():
         # Root actor can always edit public status
-        if actor and actor.get("id") == "root" and action == "public-tables":
+        if actor and actor.get("id") == "root" and action == "datasette-public":
             return True
         if action == "execute-sql" and not actor:
-            return await datasette.permission_allowed(
-                actor, "view-database", resource=resource
+            is_public, allow_sql = await database_privacy_settings(datasette, resource)
+            print(
+                "Check for actor",
+                actor,
+                "is_public",
+                "resource",
+                resource,
+                " - result: is_public",
+                is_public,
+                "allow_sql",
+                allow_sql,
             )
-        if action != "view-table":
+            if not allow_sql:
+                return allow_sql
+        if action not in ("view-table", "view-database"):
             return None
-        # Say 'yes' if this table is public
-        database_name, table_name = resource
-        db = db_from_config(datasette)
-        if await table_is_public(db, table_name):
+        if action == "view-table" and await table_is_public(
+            datasette, resource[0], resource[1]
+        ):
             return True
+        if action == "view-database":
+            is_public, _ = await database_privacy_settings(datasette, resource)
+            if is_public:
+                return True
 
     return inner
 
 
-async def table_is_public(db, table_name):
-    # TODO: include database_name in check
+async def table_is_public(datasette, database_name, table_name):
+    db = datasette.get_internal_database()
     rows = await db.execute(
-        "select 1 from _public_tables where table_name = ?", [table_name]
+        "select 1 from public_tables where database_name = ? and table_name = ?",
+        (database_name, table_name),
     )
-    if len(rows):
-        return True
+    return bool(len(rows))
+
+
+async def database_privacy_settings(datasette, database_name) -> Tuple[bool, bool]:
+    db = datasette.get_internal_database()
+    result = await db.execute(
+        "select 1, allow_sql from public_databases where database_name = ?",
+        [database_name],
+    )
+    row = result.first()
+    if not row:
+        return (False, False)
+    return (True, bool(row["allow_sql"]))
 
 
 @hookimpl
 def table_actions(datasette, actor, database, table):
     async def inner():
         if not await datasette.permission_allowed(
-            actor, "public-tables", resource=database, default=False
+            actor, "datasette-public", resource=database, default=False
         ):
             return []
-        if database != "_internal":
-            noun = "table"
-            if table in await datasette.get_database(database).view_names():
-                noun = "view"
-            is_private = not await table_is_public(db_from_config(datasette), table)
-            return [
-                {
-                    "href": datasette.urls.path(
-                        "/-/public-table/{}/{}".format(database, quote_plus(table))
-                    ),
-                    "label": "Make {} {}".format(
-                        noun, "public" if is_private else "private"
-                    ),
-                    "description": (
-                        "Allow anyone to view this {}".format(noun)
-                        if is_private
-                        else "Only allow logged-in users to view this {}".format(noun)
-                    ),
-                }
-            ]
+        noun = "table"
+        if table in await datasette.get_database(database).view_names():
+            noun = "view"
+        is_private = not await table_is_public(datasette, database, table)
+        return [
+            {
+                "href": datasette.urls.path(
+                    "/-/public-table/{}/{}".format(database, quote_plus(table))
+                ),
+                "label": "Make {} {}".format(
+                    noun, "public" if is_private else "private"
+                ),
+                "description": (
+                    "Allow anyone to view this {}".format(noun)
+                    if is_private
+                    else "Only allow logged-in users to view this {}".format(noun)
+                ),
+            }
+        ]
 
     return inner
 
 
+@hookimpl
+def database_actions(datasette, actor, database):
+    async def inner():
+        if not await datasette.permission_allowed(
+            actor, "datasette-public", resource=database, default=False
+        ):
+            return []
+        is_public, _ = await database_privacy_settings(datasette, database)
+        return [
+            {
+                "href": datasette.urls.path(
+                    "/-/public-database/{}".format(quote_plus(database))
+                ),
+                "label": "Make database {}".format(
+                    "private" if not is_public else "public"
+                ),
+                "description": (
+                    "Only allow logged-in users to view this database"
+                    if is_public
+                    else "Allow anyone to view this database"
+                ),
+            }
+        ]
+
+    return inner
+
+
+@hookimpl
+def view_actions(datasette, actor, database, view):
+    return table_actions(datasette, actor, database, view)
+
+
 async def check_permissions(datasette, request, database):
-    if database == "_internal" or not await datasette.permission_allowed(
-        request.actor, "public-tables", resource=database, default=False
+    if not await datasette.permission_allowed(
+        request.actor, "datasette-public", resource=database, default=False
     ):
         raise Forbidden("Permission denied for changing table privacy")
 
@@ -99,7 +165,7 @@ async def change_table_privacy(request, datasette):
     ):
         raise NotFound("{} not found".format(noun))
 
-    permission_db = db_from_config(datasette)
+    permission_db = datasette.get_internal_database()
 
     if request.method == "POST":
         form_data = await request.post_vars()
@@ -107,17 +173,19 @@ async def change_table_privacy(request, datasette):
         if action == "make-public":
             msg = "public"
             await permission_db.execute_write(
-                "insert or ignore into _public_tables (table_name) values (?)", [table]
+                "insert or ignore into public_tables (database_name, table_name) values (?, ?)",
+                [database_name, table],
             )
         elif action == "make-private":
             msg = "private"
             await permission_db.execute_write(
-                "delete from _public_tables where table_name = ?", [table]
+                "delete from public_tables where database_name = ? and table_name = ?",
+                [database_name, table],
             )
         datasette.add_message(request, "{} '{}' is now {}".format(noun, table, msg))
         return Response.redirect(datasette.urls.table(database_name, table))
 
-    is_private = not await table_is_public(permission_db, table)
+    is_private = not await table_is_public(datasette, database_name, table)
 
     return Response.html(
         await datasette.render_template(
@@ -133,6 +201,46 @@ async def change_table_privacy(request, datasette):
     )
 
 
+async def change_database_privacy(request, datasette):
+    database_name = request.url_vars["database"]
+    await check_permissions(datasette, request, database_name)
+    permission_db = datasette.get_internal_database()
+
+    if request.method == "POST":
+        form_data = await request.post_vars()
+        allow_sql = bool(form_data.get("allow_sql"))
+        action = form_data.get("action")
+        if action == "make-public":
+            msg = "public"
+            await permission_db.execute_write(
+                "insert or replace into public_databases (database_name, allow_sql) values (?, ?)",
+                (database_name, allow_sql),
+            )
+        elif action == "make-private":
+            msg = "private"
+            await permission_db.execute_write(
+                "delete from public_databases where database_name = ?", [database_name]
+            )
+        datasette.add_message(
+            request, "Database '{}' is now {}".format(database_name, msg)
+        )
+        return Response.redirect(datasette.urls.database(database_name))
+
+    is_public, allow_sql = await database_privacy_settings(datasette, database_name)
+
+    return Response.html(
+        await datasette.render_template(
+            "public_database_change_privacy.html",
+            {
+                "database": database_name,
+                "is_private": not is_public,
+                "allow_sql": allow_sql,
+            },
+            request=request,
+        )
+    )
+
+
 @hookimpl
 def register_routes():
     return [
@@ -140,10 +248,8 @@ def register_routes():
             r"^/-/public-table/(?P<database>[^/]+)/(?P<table>[^/]+)$",
             change_table_privacy,
         ),
+        (
+            r"^/-/public-database/(?P<database>[^/]+)$",
+            change_database_privacy,
+        ),
     ]
-
-
-def db_from_config(datasette):
-    config = datasette.plugin_config("datasette-public") or {}
-    db_name = config.get("database") or None
-    return datasette.get_database(db_name)

--- a/datasette_public/templates/public_database_change_privacy.html
+++ b/datasette_public/templates/public_database_change_privacy.html
@@ -9,40 +9,46 @@
 {% block content %}
 <h1>Edit database privacy: <a href="{{ urls.database(database) }}">{{ database }}</a></h1>
 
-<form class="core" id="database-privacy-form" action="{{ base_url }}-/public-database/{{ database|quote_plus }}" method="post">
-<p>Database is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>
-<p>
-    <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
-    <p> <!-- radio buttons for make-public / make-private action-->
-      <input type="radio" name="action" id="make-public" value="make-public" {% if not is_private %}checked{% endif %}>
-      <label for="make-public">Database is public</label> - anyone can access it
-    </p>
-    <p>
-      <input type="radio" name="action" id="make-private" value="make-private" {% if is_private %}checked{% endif %}>
-      <label for="make-private">Database is private</label> - only authorized users can access it
-    </p>
-    <p id="allow-sql-wrapper">
-      <input type="checkbox" name="allow_sql" id="allow_sql" {% if allow_sql %}checked{% endif %}>
-      <label for="allow_sql">Allow public users to run read-only SQL queries</label>
-    </p>
-    <input type="submit" value="Update database privacy">
-</p>
-</form>
+{% if instance_is_public %}
+    <p>This Datasette instance is currently public, so you cannot change the visibility of this database.</p>
+{% else %}
 
-<script>
-function showHideSqlWrapper() {
-    var allowSqlWrapper = document.getElementById('allow-sql-wrapper');
-    var form = document.querySelector('#database-privacy-form');
-    if (form.action.value === 'make-public') {
-        allowSqlWrapper.style.display = 'block';
-    } else {
-        allowSqlWrapper.style.display = 'none';
+    <form class="core" id="database-privacy-form" action="{{ base_url }}-/public-database/{{ database|quote_plus }}" method="post">
+    <p>Database is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>
+    <p>
+        <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+        <p> <!-- radio buttons for make-public / make-private action-->
+          <input type="radio" name="action" id="make-public" value="make-public" {% if not is_private %}checked{% endif %}>
+          <label for="make-public">Database is public</label> - anyone can access it
+        </p>
+        <p>
+          <input type="radio" name="action" id="make-private" value="make-private" {% if is_private %}checked{% endif %}>
+          <label for="make-private">Database is private</label> - only authorized users can access it
+        </p>
+        <p id="allow-sql-wrapper">
+          <input type="checkbox" name="allow_sql" id="allow_sql" {% if allow_sql %}checked{% endif %}>
+          <label for="allow_sql">Allow public users to run read-only SQL queries</label>
+        </p>
+        <input type="submit" value="Update database privacy">
+    </p>
+    </form>
+
+    <script>
+    function showHideSqlWrapper() {
+        var allowSqlWrapper = document.getElementById('allow-sql-wrapper');
+        var form = document.querySelector('#database-privacy-form');
+        if (form.action.value === 'make-public') {
+            allowSqlWrapper.style.display = 'block';
+        } else {
+            allowSqlWrapper.style.display = 'none';
+        }
     }
-}
-document.querySelectorAll('input[type=radio]').forEach(function(radio) {
-    radio.addEventListener('change', showHideSqlWrapper);
-});
-showHideSqlWrapper();
-</script>
+    document.querySelectorAll('input[type=radio]').forEach(function(radio) {
+        radio.addEventListener('change', showHideSqlWrapper);
+    });
+    showHideSqlWrapper();
+    </script>
+
+{% endif %}
 
 {% endblock %}

--- a/datasette_public/templates/public_database_change_privacy.html
+++ b/datasette_public/templates/public_database_change_privacy.html
@@ -9,7 +9,7 @@
 {% block content %}
 <h1>Edit database privacy: <a href="{{ urls.database(database) }}">{{ database }}</a></h1>
 
-<form id="database-privacy-form" action="{{ base_url }}-/public-database/{{ database|quote_plus }}" method="post">
+<form class="core" id="database-privacy-form" action="{{ base_url }}-/public-database/{{ database|quote_plus }}" method="post">
 <p>Database is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>
 <p>
     <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">

--- a/datasette_public/templates/public_database_change_privacy.html
+++ b/datasette_public/templates/public_database_change_privacy.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+
+{% block title %}Change privacy for {{ database }}{% endblock %}
+
+{% block crumbs %}
+{{ crumbs.nav(request=request, database=database) }}
+{% endblock %}
+
+{% block content %}
+<h1>Edit database privacy: <a href="{{ urls.database(database) }}">{{ database }}</a></h1>
+
+<form id="database-privacy-form" action="{{ base_url }}-/public-database/{{ database|quote_plus }}" method="post">
+<p>Database is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>
+<p>
+    <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+    <p> <!-- radio buttons for make-public / make-private action-->
+      <input type="radio" name="action" id="make-public" value="make-public" {% if not is_private %}checked{% endif %}>
+      <label for="make-public">Database is public</label> - anyone can access it
+    </p>
+    <p>
+      <input type="radio" name="action" id="make-private" value="make-private" {% if is_private %}checked{% endif %}>
+      <label for="make-private">Database is private</label> - only authorized users can access it
+    </p>
+    <p id="allow-sql-wrapper">
+      <input type="checkbox" name="allow_sql" id="allow_sql" {% if allow_sql %}checked{% endif %}>
+      <label for="allow_sql">Allow public users to run read-only SQL queries</label>
+    </p>
+    <input type="submit" value="Update database privacy">
+</p>
+</form>
+
+<script>
+function showHideSqlWrapper() {
+    var allowSqlWrapper = document.getElementById('allow-sql-wrapper');
+    var form = document.querySelector('#database-privacy-form');
+    if (form.action.value === 'make-public') {
+        allowSqlWrapper.style.display = 'block';
+    } else {
+        allowSqlWrapper.style.display = 'none';
+    }
+}
+document.querySelectorAll('input[type=radio]').forEach(function(radio) {
+    radio.addEventListener('change', showHideSqlWrapper);
+});
+showHideSqlWrapper();
+</script>
+
+{% endblock %}

--- a/datasette_public/templates/public_table_change_privacy.html
+++ b/datasette_public/templates/public_table_change_privacy.html
@@ -9,13 +9,18 @@
 {% block content %}
 <h1>Edit {{ noun }} privacy: <a href="{{ urls.table(database, table) }}">{{ database }}/{{ table }}</a></h1>
 
-<form class="core" action="{{ base_url }}-/public-table/{{ database|quote_plus }}/{{ table|quote_plus }}" method="post">
-<p>{{ noun|title }} is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>
-<p>
-    <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
-    <input type="hidden" name="action" value="{% if is_private %}make-public{% else %}make-private{% endif %}">
-    <input type="submit" value="{% if is_private %}Make public{% else %}Make private{% endif %}">
-</p>
-</form>
+{% if database_is_public %}
+    <p>The <strong>{{ database }}</strong> database is currently public, so you cannot change the visibility of this {{ noun }}.</p>
+{% else %}
+
+    <form class="core" action="{{ base_url }}-/public-table/{{ database|quote_plus }}/{{ table|quote_plus }}" method="post">
+    <p>{{ noun|title }} is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>
+    <p>
+        <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+        <input type="hidden" name="action" value="{% if is_private %}make-public{% else %}make-private{% endif %}">
+        <input type="submit" value="{% if is_private %}Make public{% else %}Make private{% endif %}">
+    </p>
+    </form>
+{% endif %}
 
 {% endblock %}

--- a/datasette_public/templates/public_table_change_privacy.html
+++ b/datasette_public/templates/public_table_change_privacy.html
@@ -9,7 +9,7 @@
 {% block content %}
 <h1>Edit {{ noun }} privacy: <a href="{{ urls.table(database, table) }}">{{ database }}/{{ table }}</a></h1>
 
-<form action="{{ base_url }}-/public-table/{{ database|quote_plus }}/{{ table|quote_plus }}" method="post">
+<form class="core" action="{{ base_url }}-/public-table/{{ database|quote_plus }}/{{ table|quote_plus }}" method="post">
 <p>{{ noun|title }} is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>
 <p>
     <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">

--- a/datasette_public/templates/public_table_change_privacy.html
+++ b/datasette_public/templates/public_table_change_privacy.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-<h1>Edit {{ noun }} privacy: <a href="{{ base_url }}{{ database|quote_plus }}/{{ table|quote_plus }}">{{ database }}/{{ table }}</a></h1>
+<h1>Edit {{ noun }} privacy: <a href="{{ urls.table(database, table) }}">{{ database }}/{{ table }}</a></h1>
 
 <form action="{{ base_url }}-/public-table/{{ database|quote_plus }}/{{ table|quote_plus }}" method="post">
 <p>{{ noun|title }} is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 asyncio_mode = strict
+asyncio_default_fixture_loop_scope = function

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     version=VERSION,
     packages=["datasette_public"],
     entry_points={"datasette": ["public = datasette_public"]},
-    install_requires=["datasette>=0.63"],
+    install_requires=["datasette>=1.0a1"],
     extras_require={"test": ["pytest", "pytest-asyncio"]},
     package_data={"datasette_public": ["templates/*"]},
     python_requires=">=3.7",

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -181,7 +181,6 @@ def _get_public_tables(db_path):
 async def test_table_actions(tmpdir, database_is_private, should_show_table_actions):
     # Tables cannot be toggled if the database they are in is public
     internal_path = str(tmpdir / "internal.db")
-    conn = sqlite3.connect(internal_path)
     data_path = str(tmpdir / "data.db")
     conn2 = sqlite3.connect(data_path)
     conn2.execute("create table t1 (id int)")

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,35 +1,31 @@
 from datasette.app import Datasette
 import pytest
+import pytest_asyncio
 import sqlite3
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("db_name", (None, "data2"))
-async def test_plugin_creates_table(tmpdir, db_name):
+@pytest_asyncio.fixture
+async def ds(tmpdir):
     db_path = str(tmpdir / "data.db")
-    db_path2 = str(tmpdir / "data2.db")
-    for path in (db_path, db_path2):
-        sqlite3.connect(path).execute("vacuum")
-    metadata = {}
-    if db_name:
-        metadata["plugins"] = {"datasette-public": {"database": db_name}}
-    ds = Datasette([db_path, db_path2], metadata=metadata)
+    internal_path = str(tmpdir / "internal.db")
+    ds = Datasette([db_path], internal=internal_path)
     await ds.invoke_startup()
-    # The database in the config should have the table now
-    if db_name:
-        assert _get_tables(db_path) == []
-        assert _get_tables(db_path2) == ["_public_tables"]
-    else:
-        assert _get_tables(db_path) == ["_public_tables"]
-        assert _get_tables(db_path2) == []
+    return ds
 
 
 @pytest.mark.asyncio
-async def test_error_if_database_is_immutable(tmpdir):
+async def test_plugin_creates_table(ds):
+    db = ds.get_internal_database()
+    table_names = await db.table_names()
+    assert "public_tables" in table_names
+    assert "public_databases" in table_names
+
+
+@pytest.mark.asyncio
+async def test_error_if_no_internal_database(tmpdir):
     db_path = str(tmpdir / "data.db")
-    sqlite3.connect(db_path).execute("vacuum")
-    ds = Datasette(immutables=[db_path])
-    with pytest.raises(AssertionError):
+    ds = Datasette(files=[db_path])
+    with pytest.raises(ValueError):
         await ds.invoke_startup()
 
 
@@ -48,20 +44,28 @@ async def test_public_table(
     tmpdir, public_instance, public_table, should_allow, is_view
 ):
     db_path = str(tmpdir / "data.db")
+    internal_path = str(tmpdir / "internal.db")
     conn = sqlite3.connect(db_path)
+    internal_conn = sqlite3.connect(internal_path)
+
+    config = {}
+    if not public_instance:
+        config["allow"] = False
+
+    ds = Datasette([db_path], internal=internal_path, config=config)
+    await ds.invoke_startup()
+
     if is_view:
         conn.execute("create view t1 as select 1")
     else:
         conn.execute("create table t1 (id int)")
     if public_table:
-        with conn:
-            conn.execute("create table _public_tables (table_name text primary key)")
-            conn.execute("insert into _public_tables (table_name) values (?)", ["t1"])
-    metadata = {}
-    if not public_instance:
-        metadata["allow"] = False
-    ds = Datasette([db_path], metadata=metadata)
-    await ds.invoke_startup()
+        with internal_conn:
+            internal_conn.execute(
+                "insert into public_tables (database_name, table_name) values (?, ?)",
+                ["data", "t1"],
+            )
+
     response = await ds.client.get("/data/t1")
     if should_allow:
         assert response.status_code == 200
@@ -72,13 +76,19 @@ async def test_public_table(
 @pytest.mark.asyncio
 async def test_where_is_denied(tmpdir):
     db_path = str(tmpdir / "data.db")
+    internal_path = str(tmpdir / "internal.db")
     conn = sqlite3.connect(db_path)
-    conn.execute("create table t1 (id int)")
-    with conn:
-        conn.execute("create table _public_tables (table_name text primary key)")
-        conn.execute("insert into _public_tables (table_name) values (?)", ["t1"])
-    ds = Datasette([db_path], metadata={"allow": False})
+    internal_conn = sqlite3.connect(internal_path)
+
+    ds = Datasette([db_path], internal=internal_path, config={"allow": False})
     await ds.invoke_startup()
+
+    conn.execute("create table t1 (id int)")
+    with internal_conn:
+        internal_conn.execute(
+            "insert into public_tables (database_name, table_name) values (? ,?)",
+            ["data", "t1"],
+        )
     # This should be allowed
     assert (await ds.client.get("/data/t1")).status_code == 200
     # This should not
@@ -86,10 +96,6 @@ async def test_where_is_denied(tmpdir):
     # Neither should this
     response = await ds.client.get("/data/t1?_where=1==1")
     assert ">1 extra where clause<" not in response.text
-    # BUT they should be allowed to use it IF they have database permission
-    ds._metadata_local["databases"] = {"data": {"allow": True}}
-    response2 = await ds.client.get("/data/t1?_where=1==1")
-    assert ">1 extra where clause<" in response2.text
 
 
 @pytest.mark.asyncio
@@ -97,6 +103,7 @@ async def test_where_is_denied(tmpdir):
 @pytest.mark.parametrize("is_view", (True, False))
 async def test_ui_for_editing_table_privacy(tmpdir, user_is_root, is_view):
     db_path = str(tmpdir / "data.db")
+    internal_path = str(tmpdir / "internal.db")
     conn = sqlite3.connect(db_path)
     noun = "table"
     if is_view:
@@ -104,15 +111,13 @@ async def test_ui_for_editing_table_privacy(tmpdir, user_is_root, is_view):
         conn.execute("create view t1 as select 1")
     else:
         conn.execute("create table t1 (id int)")
-    ds = Datasette([db_path], metadata={"allow": {"id": "*"}})
+    ds = Datasette([db_path], internal=internal_path, metadata={"allow": {"id": "*"}})
     await ds.invoke_startup()
     # Regular user can see table but not edit privacy
     cookies = {
         "ds_actor": ds.sign({"a": {"id": "root" if user_is_root else "user"}}, "actor")
     }
-    menu_fragment = '<li><a href="/-/public-table/data/t1">Make {} public</a>'.format(
-        noun
-    )
+    menu_fragment = '<li><a href="/-/public-table/data/t1">Make {} public'.format(noun)
     response = await ds.client.get("/data/t1", cookies=cookies)
     if user_is_root:
         assert menu_fragment in response.text
@@ -133,7 +138,7 @@ async def test_ui_for_editing_table_privacy(tmpdir, user_is_root, is_view):
     assert "{} is currently <strong>private</strong>".format(noun.title()) in html
     assert '<input type="hidden" name="action" value="make-public">' in html
     assert '<input type="submit" value="Make public">' in html
-    assert _get_public_tables(db_path) == []
+    assert _get_public_tables(internal_path) == []
     csrftoken = response2.cookies["ds_csrftoken"]
     cookies["ds_csrftoken"] = csrftoken
     response3 = await ds.client.post(
@@ -143,7 +148,7 @@ async def test_ui_for_editing_table_privacy(tmpdir, user_is_root, is_view):
     )
     assert response3.status_code == 302
     assert response3.headers["location"] == "/data/t1"
-    assert _get_public_tables(db_path) == ["t1"]
+    assert _get_public_tables(internal_path) == ["t1"]
     # And toggle it private again
     response4 = await ds.client.get("/-/public-table/data/t1", cookies=cookies)
     html2 = response4.text
@@ -157,18 +162,9 @@ async def test_ui_for_editing_table_privacy(tmpdir, user_is_root, is_view):
     )
     assert response5.status_code == 302
     assert response5.headers["location"] == "/data/t1"
-    assert _get_public_tables(db_path) == []
+    assert _get_public_tables(internal_path) == []
 
 
 def _get_public_tables(db_path):
     conn = sqlite3.connect(db_path)
-    return [row[0] for row in conn.execute("select table_name from _public_tables")]
-
-
-def _get_tables(path):
-    return [
-        r[0]
-        for r in sqlite3.connect(path)
-        .execute("select name from sqlite_master where type = 'table'")
-        .fetchall()
-    ]
+    return [row[0] for row in conn.execute("select table_name from public_tables")]


### PR DESCRIPTION
- #6
- #9

TODO:

- [x] Make sure the `execute-sql` permissions are working correctly
- [x] Test it out
- [x] Fix GitHub Actions workflows
- [x] Make forms look nicer
- [x] Fix bug where database menu item says "make public" when it is public already
- [x] Don't show menu item for table permissions management if database is public
- [x] If user URL-hacks their way to the table permissions page anyway show a message about the DB being public
- [x] Don't show database actions if entire instance is public