### PR TITLE
More fixes  for --default-deny mode

### DIFF
--- a/datasette_public/templates/public_database_change_privacy.html
+++ b/datasette_public/templates/public_database_change_privacy.html
@@ -9,10 +9,8 @@
 {% block content %}
 <h1>Edit database privacy: <a href="{{ urls.database(database) }}">{{ database }}</a></h1>
 
-{% if instance_is_public %}
-    <p>This Datasette instance is currently public, so you cannot change the visibility of this database.</p>
-{% else %}
-
+{% if default_deny %}
+    {# In default-deny mode: toggle public/private via public_databases #}
     <form class="core" id="database-privacy-form" action="{{ base_url }}-/public-database/{{ database|quote_plus }}" method="post">
     <p>Database is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>
     <p>
@@ -49,6 +47,16 @@
     showHideSqlWrapper();
     </script>
 
+{% else %}
+    {# Without default-deny: toggle hidden/visible via private_databases #}
+    <form class="core" action="{{ base_url }}-/public-database/{{ database|quote_plus }}" method="post">
+    <p>Database is currently <strong>{% if is_hidden %}hidden from anonymous users{% else %}visible to everyone{% endif %}</strong></p>
+    <p>
+        <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+        <input type="hidden" name="action" value="{% if is_hidden %}make-public{% else %}make-private{% endif %}">
+        <input type="submit" value="{% if is_hidden %}Make visible to anonymous users{% else %}Hide from anonymous users{% endif %}">
+    </p>
+    </form>
 {% endif %}
 
 {% include "_public_audit_log.html" %}

--- a/datasette_public/templates/public_table_change_privacy.html
+++ b/datasette_public/templates/public_table_change_privacy.html
@@ -9,16 +9,35 @@
 {% block content %}
 <h1>Edit {{ noun }} privacy: <a href="{{ urls.table(database, table) }}">{{ database }}/{{ table }}</a></h1>
 
-{% if database_is_public %}
-    <p>The <strong>{{ database }}</strong> database is currently public, so you cannot change the visibility of this {{ noun }}.</p>
+{% if default_deny %}
+    {# In default-deny mode #}
+    {% if database_has_public_sql %}
+        <p>The <strong>{{ database }}</strong> database is public with SQL queries enabled, so you cannot change the visibility of this {{ noun }}.</p>
+        <p>Users could still access the data using SQL queries even if this {{ noun }} was marked as private.</p>
+        <p>To restrict access to this {{ noun }}, first <a href="{{ base_url }}-/public-database/{{ database|quote_plus }}">disable public SQL queries on the database</a>.</p>
+    {% elif database_is_public and not database_public_sql_disabled %}
+        <p>The <strong>{{ database }}</strong> database is currently public, so you cannot change the visibility of this {{ noun }}.</p>
+    {% else %}
+        <form class="core" action="{{ base_url }}-/public-table/{{ database|quote_plus }}/{{ table|quote_plus }}" method="post">
+        <p>{{ noun|title }} is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>
+        {% if database_public_sql_disabled %}
+        <p><em>The database is public but SQL queries are disabled, so you can hide individual {{ noun }}s.</em></p>
+        {% endif %}
+        <p>
+            <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+            <input type="hidden" name="action" value="{% if is_private %}make-public{% else %}make-private{% endif %}">
+            <input type="submit" value="{% if is_private %}Make public{% else %}Make private{% endif %}">
+        </p>
+        </form>
+    {% endif %}
 {% else %}
-
+    {# Without default-deny: toggle hidden/visible via private_tables #}
     <form class="core" action="{{ base_url }}-/public-table/{{ database|quote_plus }}/{{ table|quote_plus }}" method="post">
-    <p>{{ noun|title }} is currently <strong>{% if is_private %}private{% else %}public{% endif %}</strong></p>
+    <p>{{ noun|title }} is currently <strong>{% if is_private %}hidden from anonymous users{% else %}visible to everyone{% endif %}</strong></p>
     <p>
         <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
         <input type="hidden" name="action" value="{% if is_private %}make-public{% else %}make-private{% endif %}">
-        <input type="submit" value="{% if is_private %}Make public{% else %}Make private{% endif %}">
+        <input type="submit" value="{% if is_private %}Make visible to anonymous users{% else %}Hide from anonymous users{% endif %}">
     </p>
     </form>
 {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers=[
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "datasette>=1.0a21",
+    "datasette>=1.0a22",
 ]
 
 [project.urls]


### PR DESCRIPTION
Change explained by Claude Code:

> The plugin now supports two fundamentally different approaches to privacy:
> 
> 1. **Default-deny mode** (`--default-deny`): Everything is private by default. The plugin uses `public_tables` and `public_databases` tables to **grant** access to specific resources.
> 
> 2. **Non-default-deny mode** (standard): Everything is public by default. The plugin uses new `private_tables` and `private_databases` tables to **hide** specific resources from anonymous users.
> 
> ## Database Schema Changes
> 
> Two new tables added to the internal database schema:
> 
> ```sql
> create table if not exists private_tables (
>     database_name text,
>     table_name text,
>     primary key (database_name, table_name)
> );
> 
> create table if not exists private_databases (
>     database_name text primary key
> );
> ```
> 
> These tables store resources that should be **hidden from anonymous users** (but remain visible to logged-in users).
> 
> ## Permission SQL Changes
> 
> ### `view-database` Permission
> 
> The `permission_resources_sql` hook now returns a union query that:
> - Grants access to databases in `public_databases` (for default-deny mode)
> - **NEW**: Denies access to databases in `private_databases` **only when actor is null** (anonymous users)
> 
> ```python
> union all
> select database_name as parent,
>        null as child,
>        0 as allow,
>        'datasette-public database is hidden from anonymous' as reason
> from private_databases
> where :actor is null
> ```
> 
> The query now accepts an `actor` parameter (JSON-serialized) to distinguish anonymous from authenticated users.
> 
> ### `view-table` Permission
> 
> Similarly updated to:
> - Grant access via `public_tables` (existing)
> - **NEW**: Grant access if the parent database is in `public_databases`
> - **NEW**: Deny access to tables in `private_tables` **only for anonymous users**
> 
> ### `view-query` Permission
> 
> Now also grants access to canned queries if their parent database is in `public_databases`.
> 
> ## New Helper Functions
> 
> ### `table_is_private(datasette, database_name, table_name)`
> Checks if a table is in the `private_tables` table (hidden from anonymous).
> 
> ### `database_is_hidden(datasette, database_name)`
> Checks if a database is in the `private_databases` table.
> 
> ## UI/UX Changes
> 
> ### Table Actions (`table_actions`)
> 
> Now branches based on `default_deny` mode:
> 
> **In default-deny mode:**
> - If database is public via plugin: shows "Change table visibility" action
> - If database is private: shows "Make table public/private" toggle using `public_tables`
> 
> **Without default-deny:**
> - If database is hidden: no table action shown (database itself is hidden)
> - Otherwise: shows "Change table visibility" using `private_tables` to hide from anonymous
> 
> ### Database Actions (`database_actions`)
> 
> Similarly branches:
> 
> **In default-deny mode:**
> - Always shows toggle between public/private via `public_databases`
> 
> **Without default-deny:**
> - Shows toggle to hide/show database from anonymous users via `private_databases`
> 
> ### Query Actions (`query_actions`)
> 
> - Now checks if database is public via plugin
> - If database is public, doesn't show query toggle (either SQL is enabled for all queries, or without SQL all canned queries are visible anyway)
> 
> ## Form Processing Changes
> 
> ### `change_table_privacy` Route
> 
> Determines which mode to operate in:
> ```python
> use_private_tables = (not default_deny) or (db_is_public_via_plugin and not db_allow_sql)
> ```
> 
> - **Using `private_tables`**: Hides tables from anonymous users (non-default-deny mode, or default-deny with public DB but SQL disabled)
> - **Using `public_tables`**: Makes tables explicitly public (default-deny mode with private database)
> 
> Message text updated accordingly:
> - Non-default-deny: "now visible to anonymous users" / "now hidden from anonymous users"
> - Default-deny: "now public" / "now private"
> 
> ### `change_database_privacy` Route
> 
> **In default-deny mode:**
> - Uses `public_databases` to toggle public/private
> - Supports `allow_sql` checkbox for enabling SQL queries
> 
> **Without default-deny:**
> - Uses `private_databases` to hide/show from anonymous
> - No SQL toggle needed (databases are accessible by default)
> 
> ## Template Changes
> 
> ### `public_database_change_privacy.html`
> 
> Now conditionally renders based on `default_deny`:
> 
> **With default-deny:**
> - Shows form to toggle public/private with SQL option
> - Text: "Database is currently **private/public**"
> 
> **Without default-deny:**
> - Shows simpler form to hide/show from anonymous
> - Text: "Database is currently **hidden from anonymous users/visible to everyone**"
> - Button: "Make visible to anonymous users" / "Hide from anonymous users"
> 
> ### `public_table_change_privacy.html`
> 
> More complex conditional logic:
> 
> **With default-deny:**
> - If database has public SQL enabled: shows message explaining table privacy is meaningless (SQL can access any data)
> - If database is public via other means: shows "database is public" message
> - Otherwise: shows public/private toggle form
> - Special case: if database is public but SQL disabled, shows form with explanation
> 
> **Without default-deny:**
> - Shows hide/show from anonymous toggle
> - Text uses "hidden from anonymous users" / "visible to everyone" language
> 
> ## New Template Variables
> 
> - `database_has_public_sql`: Boolean indicating database is public via plugin with SQL enabled
> - `database_public_sql_disabled`: Boolean indicating database is public but SQL disabled
> - `default_deny`: Boolean indicating whether Datasette is in default-deny mode
> - `is_hidden`: Boolean for database template indicating if database is in `private_databases`
> 
> ## Test Changes
> 
> ### Updated Existing Tests
> 
> - `test_audit_logs`: Now explicitly uses `default_deny=True`
> - `test_ui_for_editing_table_privacy`: Now explicitly uses `default_deny=True`
> - `test_table_actions`: Uses `default_deny=True` and updated config approach for making database public via config
> - `test_database_actions`: Updated expectations - now shows action even when instance allows all (in default-deny mode)
> 
> ### New Tests
> 
> 1. **`test_database_privacy_form_shown_without_default_deny`**: Verifies form is shown without default-deny mode with correct "hide from anonymous" language
> 
> 2. **`test_private_table_still_visible_to_logged_in_user`**: Regression test for the `:actor` binding parameter bug - ensures private tables are hidden from anonymous but visible to logged-in users
> 
> 3. **`test_database_privacy_form_shown_with_default_deny`**: Verifies form is shown with default-deny mode
> 
> 4. **`test_hide_from_anonymous_without_default_deny`**: Parametrized test covering both databases and tables - tests the full flow of hiding from anonymous and making visible again
> 
> ## Key Behavioral Summary
> 
> | Mode | Resource | Make Public | Make Private |
> |------|----------|-------------|--------------|
> | default-deny | Database | Add to `public_databases` | Remove from `public_databases` |
> | default-deny | Table (private DB) | Add to `public_tables` | Remove from `public_tables` |
> | default-deny | Table (public DB, no SQL) | Remove from `private_tables` | Add to `private_tables` |
> | non-default-deny | Database | Remove from `private_databases` | Add to `private_databases` |
> | non-default-deny | Table | Remove from `private_tables` | Add to `private_tables` |
> 
> The key insight is that in non-default-deny mode, "private" means "hidden from anonymous users" rather than "completely inaccessible."

Refs:
- #16